### PR TITLE
only look for single '+', file paths often match to AWS secret

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -22,7 +22,7 @@ match=0
 for i in "${!patterns[@]}"
 do
   git diff-index -p -M --cached HEAD -- |
-  grep '^+' | grep -Eq "${patterns[$i]}" &&
+  grep '^+[^+]' | grep -Eq "${patterns[$i]}" &&
   echo "Blocking commit: ${descriptions[$i]} detected in patch" &&
   ((match++))
 done


### PR DESCRIPTION
tested on MacOS and Fedora