### PR TITLE
Improved this check

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,45 +1,44 @@
 #!/bin/bash
 
 declare -a patterns=(
-  "\b[A-Z0-9]{20}\b"
-  "\b[A-Za-z0-9\/+=]{40}\b"
-  "\b[0-9]{12}\b"
-  "\b[a-z0-9]{32}\b"
-  "\b[A-Z]{2}[0-9]{6}[A-Z]{1}\b"
-  "\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b"
-  "PRIVATE KEY-----"
-  "\b[A-Za-z0-9._%+-]{1,}@[A-Za-z0-9]{1,}.[A-Za-z0-9]{1,4}.[A-Za-z0-9]{1,4}\b"
-  "\b.[a-z]{2}-[a-z]{4,9}-[0-9]{1}.\b"
+    "\b[A-Z0-9]{20}\b"
+    "\b[A-Za-z0-9\/+=]{40}\b"
+    "\b[0-9]{12}\b"
+    "\b[a-z0-9]{32}\b"
+    "\b[A-Z]{2}[0-9]{6}[A-Z]{1}\b"
+    "\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b"
+    "PRIVATE KEY-----"
+    "\b[A-Za-z0-9._%+-]{1,}@[A-Za-z0-9]{1,}.[A-Za-z0-9]{1,4}.[A-Za-z0-9]{1,4}\b"
+    "\b.[a-z]{2}-[a-z]{4,9}-[0-9]{1}.\b"
 )
 
 declare -a descriptions=(
-  "AWS access key ID"
-  "40 character random (e.g. AWS secret access key, PAT)"
-  "AWS account number"
-  "16 byte hex (e.g. S3 bucket name)"
-  "NINO"
-  "IP address"
-  "Private key (e.g. rsa private key, openssh private key)"
-  "Email addresses"
-  "Regions embedded as part of resource descriptions"
+    "AWS access key ID"
+    "40 character random (e.g. AWS secret access key, PAT)"
+    "AWS account number"
+    "16 byte hex (e.g. S3 bucket name)"
+    "NINO"
+    "IP address"
+    "Private key (e.g. rsa private key, openssh private key)"
+    "Email addresses"
+    "Regions embedded as part of resource descriptions"
 )
 
-count=`ls -1 *.secret 2>/dev/null | wc -l`
-if [ count != 0 ]; then
+if [ -d ".gitsecret" ]; then
     git secret hide
 fi
 
 match=0
 for i in "${!patterns[@]}"
 do
-  git diff-index -p -M --cached HEAD -- |
-  grep '^+[^+]' | grep -Eq "${patterns[$i]}" &&
-  echo "Blocking commit: ${descriptions[$i]} detected in patch" &&
-  ((match++))
+    git diff-index -p -M --cached HEAD -- |
+    grep '^+[^+]' | grep -Eq "${patterns[$i]}" &&
+    echo "Blocking commit: ${descriptions[$i]} detected in patch" &&
+    ((match++))
 done
 
 if (( match > 0 )); then
-  echo "If the above are false positives then you can use the --no-verify flag to skip checks"
-  echo "git commit --no-verify"
-  exit 1
+    echo "If the above are false positives then you can use the --no-verify flag to skip checks"
+    echo "git commit --no-verify"
+    exit 1
 fi


### PR DESCRIPTION
The previous check wasn't working as intended.  This, simply checks for the `.gitsecret` folder that will always exists in a secret repository.