### PR TITLE
Skip Githooks repo when deploying githooks

### DIFF
--- a/ci/jobs/deploy_commit_hooks.yml.j2
+++ b/ci/jobs/deploy_commit_hooks.yml.j2
@@ -5,17 +5,17 @@ jobs:
       - in_parallel:
           - get: dataworks-github-config-githooks
             trigger: true
-          {% for repo in repos %}
-          - get: {{ repo }}{% endfor %}
+          {% for repo in repos %}{% if not 'dataworks-githooks' in repo  %}
+          - get: {{ repo }}{% endif %}{% endfor %}
       - task: commit-and-push
         config:
           inputs:
             - name: dataworks-github-config-githooks
-            {% for repo in repos %}
-            - name: {{ repo }}{% endfor %}
+            {% for repo in repos %}{% if not 'dataworks-githooks' in repo  %}
+            - name: {{ repo }}{% endif %}{% endfor %}
           outputs:
-            {% for repo in repos %}
-            - name: {{ repo }}-modified{% endfor %}
+            {% for repo in repos %}{% if not 'dataworks-githooks' in repo  %}
+            - name: {{ repo }}-modified{% endif %}{% endfor %}
           platform: linux
           image_resource:
             type: docker-image
@@ -29,7 +29,7 @@ jobs:
               - |
                 git config --global user.name "${GIT_USERNAME}"
                 git config --global user.email "${GIT_EMAIL}"
-                {% for repo in repos %}
+                {% for repo in repos %}{% if not 'dataworks-githooks' in repo  %}
                 git clone {{ repo }} {{ repo }}-modified
                 cd {{ repo }}-modified
                 git remote set-url origin https://github.com/dwp/{{ repo }}.git
@@ -41,12 +41,12 @@ jobs:
                   git add Makefile
                   git diff --quiet && git diff --staged --quiet || git commit -m "create Makefile from dataworks-github-config/Makefile.sample"
                 fi
-                cd ..{% endfor %}
+                cd ..{% endif %}{% endfor %}
         params:
           GIT_USERNAME: ((dataworks.concourse_github_username))
           GIT_EMAIL: ((dataworks.concourse_github_email))
       - in_parallel:
-        {% for repo in repos %}
+        {% for repo in repos %}{% if not 'dataworks-githooks' in repo  %}
         - put: {{ repo }}
           params:
-            repository: {{ repo }}-modified{% endfor %}
+            repository: {{ repo }}-modified{% endif %}{% endfor %}

--- a/ci/repo_resources.yml.j2
+++ b/ci/repo_resources.yml.j2
@@ -1,5 +1,5 @@
 resources:
-{% for repo in repos %}
+{% for repo in repos %}{% if not 'dataworks-githooks' in repo  %}
 - name: {{ repo }}
   type: git
   source:
@@ -13,4 +13,4 @@ resources:
       - name: user.email
         value: ((dataworks.concourse_github_email))
   check_every: 5m
-{% endfor %}
+{% endif %}{% endfor %}


### PR DESCRIPTION
We don't want to deploy the old githooks to the new githooks repository.