### PR TITLE
Point githooks resource at githooks repo. 

### DIFF
--- a/ci/resources.yml
+++ b/ci/resources.yml
@@ -5,12 +5,14 @@ resources:
       branch: master
       uri: https://github.com/dwp/dataworks-github-config.git
     webhook_token: ((dataworks.concourse_github_webhook_token))
+    check_every: 720h
   - name: dataworks-github-config-githooks
     type: git
     source:
       branch: master
       uri: https://github.com/dwp/dataworks-githooks.git
     webhook_token: ((dataworks.concourse_github_webhook_token))
+    check_every: 720h
   - name: dataworks-github-config-pr
     type: pull-request
     source:
@@ -18,3 +20,4 @@ resources:
       uri: https://github.com/dwp/dataworks-github-config.git
       access_token: ((dataworks-secrets.concourse_github_pat))
     webhook_token: ((dataworks.concourse_github_webhook_token))
+    check_every: 720h

--- a/ci/resources.yml
+++ b/ci/resources.yml
@@ -5,16 +5,12 @@ resources:
       branch: master
       uri: https://github.com/dwp/dataworks-github-config.git
     webhook_token: ((dataworks.concourse_github_webhook_token))
-    check_every: 720h
   - name: dataworks-github-config-githooks
     type: git
     source:
       branch: master
-      uri: https://github.com/dwp/dataworks-github-config.git
-      paths:
-        - .githooks/**
+      uri: https://github.com/dwp/dataworks-githooks.git
     webhook_token: ((dataworks.concourse_github_webhook_token))
-    check_every: 720h
   - name: dataworks-github-config-pr
     type: pull-request
     source:
@@ -22,4 +18,3 @@ resources:
       uri: https://github.com/dwp/dataworks-github-config.git
       access_token: ((dataworks-secrets.concourse_github_pat))
     webhook_token: ((dataworks.concourse_github_webhook_token))
-    check_every: 720h


### PR DESCRIPTION
Pointed the githooks job at the new single point of truth for githooks.
Also removed the `check_every` setting on resources, now that we're in AWS, the rate limit isn't an issue and we have direct access unlike from Crown.