### PR TITLE
Removing template license generation

### DIFF
--- a/template-repository.tf.sample
+++ b/template-repository.tf.sample
@@ -2,7 +2,6 @@ resource "github_repository" "example" {
   name             = "example"
   description      = "example"
   auto_init        = true
-  license_template = "isc"
 
   allow_merge_commit = false
   has_issues         = true

--- a/terraform-template-repository.tf.sample
+++ b/terraform-template-repository.tf.sample
@@ -2,7 +2,6 @@ resource "github_repository" "example" {
   name             = "example"
   description      = "example"
   auto_init        = true
-  license_template = "isc"
 
   allow_merge_commit = false
   has_issues         = true


### PR DESCRIPTION
Removing from the sample repo files, as it is over written when using a repository template.  Added licenses to the template instead.