### PR TITLE
Init linux fixes

### DIFF
--- a/docker-template-repository.tf.sample
+++ b/docker-template-repository.tf.sample
@@ -42,7 +42,7 @@ resource "null_resource" "example" {
     repo = "${github_repository.example.name}"
   }
   provisioner "local-exec" {
-    command = "./initial-commit.sh ${github_repository.example.name}"
+    command = "./initial-commit.sh ${github_repository.example.name} '${github_repository.example.description}'"
   }
 }
 

--- a/initial-commit-tf.sh
+++ b/initial-commit-tf.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 TF_REPO_NAME=dataworks-repo-template-terraform
 NEW_REPO_NAME=$1
+REPO_DESCRIPTION="$2"
 
 git config --global user.name "${GIT_USERNAME}"
 git config --global user.email "${GIT_EMAIL}"
@@ -9,12 +10,12 @@ git clone https://github.com/dwp/$NEW_REPO_NAME
 cd $NEW_REPO_NAME
 
 git submodule add https://github.com/dwp/dataworks-githooks .githooks
-make git-hooks
 
-find ci -type f -exec sed -i '' "s/$TF_REPO_NAME/$NEW_REPO_NAME/g" {} +
-find terraform -type f -exec sed -i '' "s/$TF_REPO_NAME/$NEW_REPO_NAME/g" {} +
-find aviator.yml -type f -exec sed -i '' "s/$TF_REPO_NAME/$NEW_REPO_NAME/g" {} +
-find README.md -type -f -exec sed -i '' "s/#\ $TF_REPO_NAME/#\ $NEW_REPO_NAME/" {} +
+find ci -type f -exec sed -i "s/$TF_REPO_NAME/$NEW_REPO_NAME/g" {} +
+find terraform -type f -exec sed -i "s/$TF_REPO_NAME/$NEW_REPO_NAME/g" {} +
+find aviator.yml -type f -exec sed -i "s/$TF_REPO_NAME/$NEW_REPO_NAME/g" {} +
+find README.md -type f -exec sed -i "s/#\ $TF_REPO_NAME/#\ $NEW_REPO_NAME/g" {} +
+find README.md -type f -exec sed -i "s/##\ Description/##\ ${REPO_DESCRIPTION}/g" {} +
 
 rm initial-commit.sh
 

--- a/initial-commit-tf.sh
+++ b/initial-commit-tf.sh
@@ -14,10 +14,9 @@ make git-hooks
 find ci -type f -exec sed -i '' "s/$TF_REPO_NAME/$NEW_REPO_NAME/g" {} +
 find terraform -type f -exec sed -i '' "s/$TF_REPO_NAME/$NEW_REPO_NAME/g" {} +
 find aviator.yml -type f -exec sed -i '' "s/$TF_REPO_NAME/$NEW_REPO_NAME/g" {} +
+find README.md -type -f -exec sed -i '' "s/#\ dataworks-repo-template/#\ my-new-repo/" {} +
 
 rm initial-commit.sh
-rm README.md
-cat $NEW_REPO_NAME > README.md
 
 git add --all
 git commit -m "Renamed pipeline and Terraform to fit repository"

--- a/initial-commit-tf.sh
+++ b/initial-commit-tf.sh
@@ -16,6 +16,8 @@ find terraform -type f -exec sed -i '' "s/$TF_REPO_NAME/$NEW_REPO_NAME/g" {} +
 find aviator.yml -type f -exec sed -i '' "s/$TF_REPO_NAME/$NEW_REPO_NAME/g" {} +
 
 rm initial-commit.sh
+rm README.md
+cat $NEW_REPO_NAME > README.md
 
 git add --all
 git commit -m "Renamed pipeline and Terraform to fit repository"

--- a/initial-commit-tf.sh
+++ b/initial-commit-tf.sh
@@ -14,7 +14,7 @@ make git-hooks
 find ci -type f -exec sed -i '' "s/$TF_REPO_NAME/$NEW_REPO_NAME/g" {} +
 find terraform -type f -exec sed -i '' "s/$TF_REPO_NAME/$NEW_REPO_NAME/g" {} +
 find aviator.yml -type f -exec sed -i '' "s/$TF_REPO_NAME/$NEW_REPO_NAME/g" {} +
-find README.md -type -f -exec sed -i '' "s/#\ dataworks-repo-template/#\ my-new-repo/" {} +
+find README.md -type -f -exec sed -i '' "s/#\ $TF_REPO_NAME/#\ $NEW_REPO_NAME/" {} +
 
 rm initial-commit.sh
 

--- a/initial-commit.sh
+++ b/initial-commit.sh
@@ -1,16 +1,18 @@
 #!/bin/sh
 REPO_NAME=dataworks-repo-template
 NEW_REPO_NAME=$1
+REPO_DESCRIPTION=$2
 
 git config --global user.name "${GIT_USERNAME}"
 git config --global user.email "${GIT_EMAIL}"
 
 git clone https://github.com/dwp/$NEW_REPO_NAME
 cd $NEW_REPO_NAME
-git submodule add https://github.com/dwp/dataworks-githooks .githooks
-make git-hooks
 
-find README.md -type -f -exec sed -i '' "s/#\ $REPO_NAME/#\ $NEW_REPO_NAME/" {} +
+git submodule add https://github.com/dwp/dataworks-githooks .githooks
+
+find README.md -type f -exec sed -i "s/#\ $REPO_NAME/#\ $NEW_REPO_NAME/" {} +
+find README.md -type f -exec sed -i "s/##\ Description/##\ ${REPO_DESCRIPTION}/g" {} +
 
 rm initial-commit.sh
 

--- a/initial-commit.sh
+++ b/initial-commit.sh
@@ -9,7 +9,7 @@ cd $NEW_REPO_NAME
 git submodule add https://github.com/dwp/dataworks-githooks .githooks
 make git-hooks
 
-find README.md -type f -exec sed -i '' "s/#\ dataworks-repo-template/#\ my-new-repo/" {} +
+find README.md -type -f -exec sed -i '' "s/#\ $TF_REPO_NAME/#\ $NEW_REPO_NAME/" {} +
 
 rm initial-commit.sh
 

--- a/initial-commit.sh
+++ b/initial-commit.sh
@@ -9,9 +9,9 @@ cd $NEW_REPO_NAME
 git submodule add https://github.com/dwp/dataworks-githooks .githooks
 make git-hooks
 
+find README.md -type f -exec sed -i '' "s/#\ dataworks-repo-template/#\ my-new-repo/" {} +
+
 rm initial-commit.sh
-rm README.md
-cat $NEW_REPO_NAME > README.md
 
 git add --all
 git commit -m "Initial commit, adding githooks submodule"

--- a/initial-commit.sh
+++ b/initial-commit.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+REPO_NAME=dataworks-repo-template
 NEW_REPO_NAME=$1
 
 git config --global user.name "${GIT_USERNAME}"
@@ -9,7 +10,7 @@ cd $NEW_REPO_NAME
 git submodule add https://github.com/dwp/dataworks-githooks .githooks
 make git-hooks
 
-find README.md -type -f -exec sed -i '' "s/#\ $TF_REPO_NAME/#\ $NEW_REPO_NAME/" {} +
+find README.md -type -f -exec sed -i '' "s/#\ $REPO_NAME/#\ $NEW_REPO_NAME/" {} +
 
 rm initial-commit.sh
 

--- a/initial-commit.sh
+++ b/initial-commit.sh
@@ -10,6 +10,8 @@ git submodule add https://github.com/dwp/dataworks-githooks .githooks
 make git-hooks
 
 rm initial-commit.sh
+rm README.md
+cat $NEW_REPO_NAME > README.md
 
 git add --all
 git commit -m "Initial commit, adding githooks submodule"

--- a/template-repository.tf.sample
+++ b/template-repository.tf.sample
@@ -42,6 +42,6 @@ resource "null_resource" "example" {
     repo = "${github_repository.example.name}"
   }
   provisioner "local-exec" {
-    command = "./initial-commit.sh ${github_repository.example.name}"
+    command = "./initial-commit.sh ${github_repository.example.name} '${github_repository.example.description}'"
   }
 }

--- a/terraform-template-repository.tf.sample
+++ b/terraform-template-repository.tf.sample
@@ -43,6 +43,6 @@ resource "null_resource" "example" {
     repo = "${github_repository.example.name}"
   }
   provisioner "local-exec" {
-    command = "./initial-commit-tf.sh ${github_repository.example.name}"
+    command = "./initial-commit-tf.sh ${github_repository.example.name} '${github_repository.example.description}'"
   }
 }


### PR DESCRIPTION
As requested README now includes the user provided repo description.

The init scripts now function fully on the linux containers ran in CI.  The main take away being it is not fully automated, the user must initialise the git hooks submodule after a clone.