### PR TITLE
change secret names so not prefixed with `GITHUB_`

### DIFF
--- a/kafka-producer.tf
+++ b/kafka-producer.tf
@@ -35,18 +35,18 @@ resource "github_branch_protection" "kafka-producer-master" {
 
 resource "github_actions_secret" "kafka-producer_github_email" {
   repository      = "${github_repository.kafka-producer.name}"
-  secret_name     = "GITHUB_EMAIL"
+  secret_name     = "CI_GITHUB_EMAIL"
   plaintext_value = "${var.github_email}"
 }
 
 resource "github_actions_secret" "kafka-producer_github_username" {
   repository      = "${github_repository.kafka-producer.name}"
-  secret_name     = "GITHUB_USERNAME"
+  secret_name     = "CI_GITHUB_USERNAME"
   plaintext_value = "${var.github_username}"
 }
 
 resource "github_actions_secret" "kafka-producer_github_token" {
   repository      = "${github_repository.kafka-producer.name}"
-  secret_name     = "GITHUB_TOKEN"
+  secret_name     = "CI_GITHUB_TOKEN"
   plaintext_value = "${var.github_token}"
 }


### PR DESCRIPTION
> Secret names must not start with the `GITHUB_` prefix.

https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets