### PR TITLE
Modify initial-commit.sh to match updated Terraform template repo

### DIFF
--- a/initial-commit.sh
+++ b/initial-commit.sh
@@ -17,6 +17,8 @@ find README.md -type f -exec sed -i "s/##\ Description/##\ ${REPO_DESCRIPTION}/g
 case "$REPO_NAME" in
     *-terraform)
         find ci -type f -exec sed -i "s/$REPO_NAME/$NEW_REPO_NAME/g" {} +
+        find ci -type f -exec sed -i s/"#ENABLE "/""/g {} +
+        find ci -type f -exec sed -i /"^.*#REMOVE.*"/d {} +
         find *.tf -type f -exec sed -i "s/$REPO_NAME/$NEW_REPO_NAME/g" {} +
         find aviator.yml -type f -exec sed -i "s/$REPO_NAME/$NEW_REPO_NAME/g" {} +
     ;;

--- a/initial-commit.sh
+++ b/initial-commit.sh
@@ -17,8 +17,8 @@ find README.md -type f -exec sed -i "s/##\ Description/##\ ${REPO_DESCRIPTION}/g
 case "$REPO_NAME" in
     *-terraform)
         find ci -type f -exec sed -i "s/$REPO_NAME/$NEW_REPO_NAME/g" {} +
-        find ci -type f -exec sed -i s/"#ENABLE "/""/g {} +
-        find ci -type f -exec sed -i /"^.*#REMOVE.*"/d {} +
+        find ci -type f -exec sed -i s/"#ENABLE_BY_INITIAL_COMMIT "/""/g {} +
+        find ci -type f -exec sed -i /"^.*#REMOVE_BY_INITIAL_COMMIT.*"/d {} +
         find *.tf -type f -exec sed -i "s/$REPO_NAME/$NEW_REPO_NAME/g" {} +
         find aviator.yml -type f -exec sed -i "s/$REPO_NAME/$NEW_REPO_NAME/g" {} +
     ;;

--- a/initial-commit.sh
+++ b/initial-commit.sh
@@ -17,7 +17,7 @@ find README.md -type f -exec sed -i "s/##\ Description/##\ ${REPO_DESCRIPTION}/g
 case "$REPO_NAME" in
     *-terraform)
         find ci -type f -exec sed -i "s/$REPO_NAME/$NEW_REPO_NAME/g" {} +
-        find terraform -type f -exec sed -i "s/$REPO_NAME/$NEW_REPO_NAME/g" {} +
+        find *.tf -type f -exec sed -i "s/$REPO_NAME/$NEW_REPO_NAME/g" {} +
         find aviator.yml -type f -exec sed -i "s/$REPO_NAME/$NEW_REPO_NAME/g" {} +
     ;;
 esac


### PR DESCRIPTION
Modify initial-commit.sh to match updated Terraform template repo
1. Modify for flat directory structure
1. Add sed steps to render TF apply and TF plan CI tasks:
    - `#ENABLE_BY_INITIAL_COMMIT` parts will be removed, thus uncommenting the lines containing that marker.
    - Lines with `#DELETE_BY_INITIAL_COMMIT` will be deleted.