### PR TITLE
Adding env vars needed for migration to github actions and slack alerts on build failure

### DIFF
--- a/ci/jobs/pull_request.yml
+++ b/ci/jobs/pull_request.yml
@@ -28,6 +28,7 @@ jobs:
             TF_VAR_dockerhub_username: ((dataworks.dockerhub_username))
             TF_VAR_dockerhub_password: ((dataworks-secrets.dockerhub_token))
             TF_VAR_snyk_token: ((dataworks-secrets.snyk_token))
+            TF_VAR_slack_webhook_url: ((dataworks.slack_webhook_url))
             TF_VAR_github_username: ((dataworks.concourse_github_username))
             TF_VAR_github_email: ((dataworks.concourse_github_email))
             TF_CLI_ARGS_plan: -lock-timeout=300s

--- a/ci/meta.yml
+++ b/ci/meta.yml
@@ -59,6 +59,7 @@ meta:
         TF_VAR_snyk_token: ((dataworks-secrets.snyk_token))
         TF_VAR_github_username: ((dataworks.concourse_github_username))
         TF_VAR_github_email: ((dataworks.concourse_github_email))
+        TF_VAR_slack_webhook_url: ((dataworks.slack_webhook_url))
         GIT_USERNAME: ((dataworks.concourse_github_username))
         GIT_EMAIL: ((dataworks.concourse_github_email))
     terraform-plan:
@@ -93,5 +94,6 @@ meta:
         TF_VAR_dockerhub_username: ((dataworks.dockerhub_username))
         TF_VAR_dockerhub_password: ((dataworks-secrets.dockerhub_token))
         TF_VAR_snyk_token: ((dataworks-secrets.snyk_token))
+        TF_VAR_slack_webhook_url: ((dataworks.slack_webhook_url))
         TF_VAR_github_username: ((dataworks.concourse_github_username))
         TF_VAR_github_email: ((dataworks.concourse_github_email))

--- a/cognito-guacamole-extension.tf
+++ b/cognito-guacamole-extension.tf
@@ -32,3 +32,27 @@ resource "github_branch_protection" "cognito-guacamole-extension-master" {
     require_code_owner_reviews = true
   }
 }
+
+resource "github_actions_secret" "cognito-guacamole-extension-dockerhub-password" {
+  repository      = "${github_repository.cognito-guacamole-extension.name}"
+  secret_name     = "DOCKERHUB_PASSWORD"
+  plaintext_value = "${var.dockerhub_password}"
+}
+
+resource "github_actions_secret" "cognito-guacamole-extension-dockerhub-username" {
+  repository      = "${github_repository.cognito-guacamole-extension.name}"
+  secret_name     = "DOCKERHUB_USERNAME"
+  plaintext_value = "${var.dockerhub_username}"
+}
+
+resource "github_actions_secret" "cognito-guacamole-extension-snyk-token" {
+  repository      = "${github_repository.cognito-guacamole-extension.name}"
+  secret_name     = "SNYK_TOKEN"
+  plaintext_value = "${var.snyk_token}"
+}
+
+resource "github_actions_secret" "cognito-guacamole-extension-slack-webhook" {
+  repository      = "${github_repository.cognito-guacamole-extension.name}"
+  secret_name     = "SLACK_WEBHOOK"
+  plaintext_value = "${var.slack_webhook_url}"
+}

--- a/docker-jupyterhub.tf
+++ b/docker-jupyterhub.tf
@@ -68,3 +68,9 @@ resource "github_actions_secret" "docker-jupyterhub-snyk-token" {
   secret_name     = "SNYK_TOKEN"
   plaintext_value = "${var.snyk_token}"
 }
+
+resource "github_actions_secret" "docker-jupyterhub-slack-webhook" {
+  repository      = "${github_repository.docker-jupyterhub.name}"
+  secret_name     = "SLACK_WEBHOOK"
+  plaintext_value = "${var.slack_webhook_url}"
+}

--- a/emr-cluster-broker.tf
+++ b/emr-cluster-broker.tf
@@ -32,3 +32,27 @@ resource "github_branch_protection" "emr-cluster-broker-master" {
     require_code_owner_reviews = true
   }
 }
+
+resource "github_actions_secret" "emr-cluster-broker-dockerhub-password" {
+  repository      = "${github_repository.emr-cluster-broker.name}"
+  secret_name     = "DOCKERHUB_PASSWORD"
+  plaintext_value = "${var.dockerhub_password}"
+}
+
+resource "github_actions_secret" "emr-cluster-broker-dockerhub-username" {
+  repository      = "${github_repository.emr-cluster-broker.name}"
+  secret_name     = "DOCKERHUB_USERNAME"
+  plaintext_value = "${var.dockerhub_username}"
+}
+
+resource "github_actions_secret" "emr-cluster-broker-snyk-token" {
+  repository      = "${github_repository.emr-cluster-broker.name}"
+  secret_name     = "SNYK_TOKEN"
+  plaintext_value = "${var.snyk_token}"
+}
+
+resource "github_actions_secret" "emr-cluster-broker-slack-webhook" {
+  repository      = "${github_repository.emr-cluster-broker.name}"
+  secret_name     = "SLACK_WEBHOOK"
+  plaintext_value = "${var.slack_webhook_url}"
+}

--- a/emr-encryption-materials-provider.tf
+++ b/emr-encryption-materials-provider.tf
@@ -32,3 +32,27 @@ resource "github_branch_protection" "emr-encryption-materials-provider-master" {
     require_code_owner_reviews = true
   }
 }
+
+resource "github_actions_secret" "emr-encryption-materials-provider-dockerhub-password" {
+  repository      = "${github_repository.emr-encryption-materials-provider.name}"
+  secret_name     = "DOCKERHUB_PASSWORD"
+  plaintext_value = "${var.dockerhub_password}"
+}
+
+resource "github_actions_secret" "emr-encryption-materials-provider-dockerhub-username" {
+  repository      = "${github_repository.emr-encryption-materials-provider.name}"
+  secret_name     = "DOCKERHUB_USERNAME"
+  plaintext_value = "${var.dockerhub_username}"
+}
+
+resource "github_actions_secret" "emr-encryption-materials-provider-snyk-token" {
+  repository      = "${github_repository.emr-encryption-materials-provider.name}"
+  secret_name     = "SNYK_TOKEN"
+  plaintext_value = "${var.snyk_token}"
+}
+
+resource "github_actions_secret" "emr-encryption-materials-provider-slack-webhook" {
+  repository = "${github_repository.emr-encryption-materials-provider.name}"
+  secret_name     = "SLACK_WEBHOOK"
+  plaintext_value = "${var.slack_webhook_url}"
+}

--- a/orchestration-service.tf
+++ b/orchestration-service.tf
@@ -71,3 +71,9 @@ resource "github_actions_secret" "orchestration-service-snyk-token" {
   secret_name     = "SNYK_TOKEN"
   plaintext_value = "${var.snyk_token}"
 }
+
+resource "github_actions_secret" "orchestration-service-slack-webhook" {
+  repository      = "${github_repository.orchestration-service.name}"
+  secret_name     = "SLACK_WEBHOOK"
+  plaintext_value = "${var.slack_webhook_url}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -49,3 +49,8 @@ variable "github_organization" {
   type        = "string"
   description = "GitHub Organisation to create repos in"
 }
+
+variable "slack_webhook_url" {
+  type        = "string"
+  description = "The webhook URL to send to Slack"
+}


### PR DESCRIPTION
* Adding `slack_webhook_url` as a variable.
* Adding `SLACK_WEBHOOK` env var to cognito-guacamole-extension, docker-jupyterhub, emr-cluster-broker, emr-encryption-materials-provider and orchestration-service repos.
* Adding `DOCKERHUB_PASSWORD`, `DOCKERHUB_USERNAME` and `SNYK_TOKEN` to the repos above that don't have them.
