### PR TITLE
Stop TF from trying to delete a repo

### DIFF
--- a/docker-hive-exporter.tf
+++ b/docker-hive-exporter.tf
@@ -1,7 +1,7 @@
 resource "github_repository" "hive_exporter" {
-  name             = "hive-exporter"
-  description      = "Prometheus exporter for hive metrics"
-  auto_init        = true
+  name        = "hive-exporter"
+  description = "Prometheus exporter for hive metrics"
+  auto_init   = false
 
   allow_merge_commit     = false
   delete_branch_on_merge = true
@@ -12,7 +12,7 @@ resource "github_repository" "hive_exporter" {
   }
 
   template {
-    owner = "${var.github_organization}"
+    owner      = "${var.github_organization}"
     repository = "dataworks-repo-template-docker"
   }
 }

--- a/docker-template-repository.tf.sample
+++ b/docker-template-repository.tf.sample
@@ -1,7 +1,7 @@
 resource "github_repository" "example" {
   name             = "example"
   description      = "example"
-  auto_init        = true
+  auto_init        = false
 
   allow_merge_commit     = false
   delete_branch_on_merge = true

--- a/template-repository.tf.sample
+++ b/template-repository.tf.sample
@@ -1,7 +1,7 @@
 resource "github_repository" "example" {
   name             = "example"
   description      = "example"
-  auto_init        = true
+  auto_init        = false
 
   allow_merge_commit     = false
   delete_branch_on_merge = true

--- a/terraform-template-repository.tf.sample
+++ b/terraform-template-repository.tf.sample
@@ -1,7 +1,7 @@
 resource "github_repository" "example" {
   name             = "example"
   description      = "example"
-  auto_init        = true
+  auto_init        = false
 
   allow_merge_commit     = false
   delete_branch_on_merge = true


### PR DESCRIPTION
When creating a repo, you can either have it auto-initialized *or* you can ask for the initial commit to come from a template repository. If you ask for both, then bad things will happen.