### PR TITLE
remove conc status requirement

### DIFF
--- a/dataworks-repo-template-terraform.tf
+++ b/dataworks-repo-template-terraform.tf
@@ -24,8 +24,7 @@ resource "github_branch_protection" "dataworks_repo_template_terraform_master" {
   enforce_admins = false
 
   required_status_checks {
-    strict   = true
-    contexts = ["concourse-ci/status"]
+    strict = true
   }
 
   required_pull_request_reviews {


### PR DESCRIPTION
Remove the requirement for a concourse check on a template repo, that deploys no code.