### PR TITLE
DW-5121 - Set dataworks-aws-tarball-ingestion repo to be destroyable

### DIFF
--- a/dataworks-aws-tarball-ingestion.tf
+++ b/dataworks-aws-tarball-ingestion.tf
@@ -9,7 +9,7 @@ resource "github_repository" "dataworks_aws_tarball_ingestion" {
   topics                 = concat(local.common_topics, local.aws_topics)
 
   lifecycle {
-    prevent_destroy = true
+    prevent_destroy = false
   }
 
   template {


### PR DESCRIPTION
Signed-off-by: Benjamin Sherwood <benjaminsherwood@digital.uc.dwp.gov.uk>