### PR TITLE
DW-5275: Allow removal of tarball-pdm repo

### DIFF
--- a/dataworks-aws-tarball-pdm.tf
+++ b/dataworks-aws-tarball-pdm.tf
@@ -9,7 +9,7 @@ resource "github_repository" "dataworks_aws_tarball_pdm" {
   topics                 = concat(local.common_topics, local.aws_topics)
 
   lifecycle {
-    prevent_destroy = true
+    prevent_destroy = false
   }
 
   template {


### PR DESCRIPTION
It turns out this isn't needed anymore