### PR TITLE
Block admins from avoid branch protection

### DIFF
--- a/acm-pca-cert-generator.tf
+++ b/acm-pca-cert-generator.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "acm-pca-cert-generator-dataworks" {
 resource "github_branch_protection" "acm-pca-cert-generator-master" {
   branch         = github_repository.acm-pca-cert-generator.default_branch
   repository     = github_repository.acm-pca-cert-generator.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/ami-builder-configs.tf
+++ b/ami-builder-configs.tf
@@ -32,7 +32,7 @@ resource "github_team_repository" "ami-builder-configs-dataworks" {
 resource "github_branch_protection" "ami-builder-configs-master" {
   branch         = github_repository.ami-builder-configs.default_branch
   repository     = github_repository.ami-builder-configs.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/ami-builder.tf
+++ b/ami-builder.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "ami-builder-dataworks" {
 resource "github_branch_protection" "ami-builder-master" {
   branch         = github_repository.ami-builder.default_branch
   repository     = github_repository.ami-builder.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/analytical-dataset-generation-exporter.tf
+++ b/analytical-dataset-generation-exporter.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "analytical_dataset_generation_exporter_datawo
 resource "github_branch_protection" "analytical_dataset_generation_exporter_master" {
   branch         = github_repository.analytical_dataset_generation_exporter.default_branch
   repository     = github_repository.analytical_dataset_generation_exporter.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/aws-analytical-dataset-generation.tf
+++ b/aws-analytical-dataset-generation.tf
@@ -23,7 +23,7 @@ resource "github_team_repository" "aws-analytical-dataset-generation_dataworks" 
 resource "github_branch_protection" "aws-analytical-dataset-generation_master" {
   branch         = github_repository.aws-analytical-dataset-generation.default_branch
   repository     = github_repository.aws-analytical-dataset-generation.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict   = true

--- a/aws-analytical-env.tf
+++ b/aws-analytical-env.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "aws-analytical-dataworks" {
 resource "github_branch_protection" "aws-analytical-env-master" {
   branch         = github_repository.aws-analytical-env.default_branch
   repository     = github_repository.aws-analytical-env.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     contexts = ["concourse-ci/status"]

--- a/aws-authentication.tf
+++ b/aws-authentication.tf
@@ -23,7 +23,7 @@ resource "github_team_repository" "aws-authentication-dataworks" {
 resource "github_branch_protection" "aws-authentication-master" {
   branch         = github_repository.aws-authentication.default_branch
   repository     = github_repository.aws-authentication.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/aws-azkaban.tf
+++ b/aws-azkaban.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "aws_azkaban_dataworks" {
 resource "github_branch_protection" "aws_azkaban_master" {
   branch         = github_repository.aws_azkaban.default_branch
   repository     = github_repository.aws_azkaban.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict   = true

--- a/aws-clive.tf
+++ b/aws-clive.tf
@@ -31,7 +31,7 @@ resource "github_team_repository" "aws_clive_dataworks" {
 resource "github_branch_protection" "aws_clive_master" {
   branch         = github_repository.aws_clive.default_branch
   repository     = github_repository.aws_clive.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/aws-cloudwatch-alerting.tf
+++ b/aws-cloudwatch-alerting.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "aws-cloudwatch-alerting-dataworks" {
 resource "github_branch_protection" "aws-cloudwatch-alerting-master" {
   branch         = github_repository.aws-cloudwatch-alerting.default_branch
   repository     = github_repository.aws-cloudwatch-alerting.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/aws-concourse.tf
+++ b/aws-concourse.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "aws-concourse-dataworks" {
 resource "github_branch_protection" "aws-concourse-master" {
   branch         = github_repository.aws-concourse.default_branch
   repository     = github_repository.aws-concourse.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/aws-emr-template-repository.tf
+++ b/aws-emr-template-repository.tf
@@ -32,7 +32,7 @@ resource "github_team_repository" "aws_emr_template_repository_dataworks" {
 resource "github_branch_protection" "aws_emr_template_repository_master" {
   branch         = github_repository.aws_emr_template_repository.default_branch
   repository     = github_repository.aws_emr_template_repository.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/aws-internet-egress.tf
+++ b/aws-internet-egress.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "aws_internet_egress_dataworks" {
 resource "github_branch_protection" "aws_internet_egress_master" {
   branch         = github_repository.aws_internet_egress.default_branch
   repository     = github_repository.aws_internet_egress.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict   = true

--- a/aws-pdm-dataset-generation.tf
+++ b/aws-pdm-dataset-generation.tf
@@ -26,7 +26,7 @@ resource "github_team_repository" "aws-pdm-dataset-generation_dataworks" {
 resource "github_branch_protection" "aws-pdm-dataset-generation_master" {
   branch         = github_repository.aws-pdm-dataset-generation.default_branch
   repository     = github_repository.aws-pdm-dataset-generation.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict   = true

--- a/aws-sns-to-ses-mailer.tf
+++ b/aws-sns-to-ses-mailer.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "aws-sns-to-ses-mailer-dataworks" {
 resource "github_branch_protection" "aws-sns-to-ses-mailer-master" {
   branch         = github_repository.aws-sns-to-ses-mailer.default_branch
   repository     = github_repository.aws-sns-to-ses-mailer.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/aws-terraform-tag-check.tf
+++ b/aws-terraform-tag-check.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "aws_terraform_tag_check_dataworks" {
 resource "github_branch_protection" "aws_terraform_tag_check_master" {
   branch         = github_repository.aws_terraform_tag_check.default_branch
   repository     = github_repository.aws_terraform_tag_check.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/bgdc-dataworks-interface.tf
+++ b/bgdc-dataworks-interface.tf
@@ -31,7 +31,7 @@ resource "github_team_repository" "dataworks_aws_bgdc_interface_dataworks" {
 resource "github_branch_protection" "dataworks_aws_bgdc_interface_master" {
   branch         = github_repository.dataworks_aws_bgdc_interface.default_branch
   repository     = github_repository.dataworks_aws_bgdc_interface.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/bgdc-interface.tf
+++ b/bgdc-interface.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "dataworks_aws_bgdc_connectivity_dataworks" {
 resource "github_branch_protection" "dataworks_aws_bgdc_connectivity_master" {
   branch         = github_repository.dataworks_aws_bgdc_connectivity.default_branch
   repository     = github_repository.dataworks_aws_bgdc_connectivity.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/cloudwatch-event-dispatcher.tf
+++ b/cloudwatch-event-dispatcher.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "cloudwatch-event-dispatcher-dataworks" {
 resource "github_branch_protection" "cloudwatch-event-dispatcher-master" {
   branch         = github_repository.cloudwatch-event-dispatcher.default_branch
   repository     = github_repository.cloudwatch-event-dispatcher.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/cognito-guacamole-extension.tf
+++ b/cognito-guacamole-extension.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "cognito-guacamole-extension-dataworks" {
 resource "github_branch_protection" "cognito-guacamole-extension-master" {
   branch         = github_repository.cognito-guacamole-extension.default_branch
   repository     = github_repository.cognito-guacamole-extension.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/concourse-control-tower.tf
+++ b/concourse-control-tower.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "concourse-control-tower-dataworks" {
 resource "github_branch_protection" "concourse-control-tower-master" {
   branch         = github_repository.concourse-control-tower.default_branch
   repository     = github_repository.concourse-control-tower.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/configure-confluent-kafka-consumer.tf
+++ b/configure-confluent-kafka-consumer.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "configure-confluent-kafka-consumer-dataworks"
 resource "github_branch_protection" "configure-confluent-kafka-consumer-master" {
   branch         = github_repository.configure-confluent-kafka-consumer.default_branch
   repository     = github_repository.configure-confluent-kafka-consumer.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/corporate-data-loader.tf
+++ b/corporate-data-loader.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "corporate_data_loader_dataworks" {
 resource "github_branch_protection" "corporate_data_loader_master" {
   branch         = github_repository.corporate_data_loader.default_branch
   repository     = github_repository.corporate_data_loader.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/data-key-service.tf
+++ b/data-key-service.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "data-key-service-dataworks" {
 resource "github_branch_protection" "data-key-service-master" {
   branch         = github_repository.data-key-service.default_branch
   repository     = github_repository.data-key-service.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/dataworks-admin-utils.tf
+++ b/dataworks-admin-utils.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "dataworks_admin_utils_dataworks" {
 resource "github_branch_protection" "dataworks_admin_utils_master" {
   branch         = github_repository.dataworks-admin-utils.default_branch
   repository     = github_repository.dataworks-admin-utils.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/dataworks-analytical-custom-auth-flow.tf
+++ b/dataworks-analytical-custom-auth-flow.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "dataworks-analytical-custom-auth-flow-datawor
 resource "github_branch_protection" "dataworks-analytical-custom-auth-flow-master" {
   branch         = github_repository.dataworks-analytical-custom-auth-flow.default_branch
   repository     = github_repository.dataworks-analytical-custom-auth-flow.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/dataworks-analytical-frontend-service.tf
+++ b/dataworks-analytical-frontend-service.tf
@@ -26,7 +26,7 @@ resource "github_team_repository" "frontend-service-dataworks" {
 resource "github_branch_protection" "frontend-service-master" {
   branch         = github_repository.frontend-service.default_branch
   repository     = github_repository.frontend-service.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/dataworks-analytical-service-infra.tf
+++ b/dataworks-analytical-service-infra.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "dataworks-analytical-service-infra_dataworks"
 resource "github_branch_protection" "dataworks-analytical-service-infra_master" {
   branch         = github_repository.dataworks-analytical-service-infra.default_branch
   repository     = github_repository.dataworks-analytical-service-infra.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict   = true

--- a/dataworks-audit-data-ingest.tf
+++ b/dataworks-audit-data-ingest.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "dataworks_audit_data_ingest_dataworks" {
 resource "github_branch_protection" "dataworks_audit_data_ingest_master" {
   branch         = github_repository.dataworks_audit_data_ingest.default_branch
   repository     = github_repository.dataworks_audit_data_ingest.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/dataworks-aws-data-egress.tf
+++ b/dataworks-aws-data-egress.tf
@@ -31,7 +31,7 @@ resource "github_team_repository" "dataworks_aws_data_egress_dataworks" {
 resource "github_branch_protection" "dataworks_aws_data_egress_master" {
   branch         = github_repository.dataworks_aws_data_egress.default_branch
   repository     = github_repository.dataworks_aws_data_egress.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/dataworks-aws-ingest-consumers.tf
+++ b/dataworks-aws-ingest-consumers.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "dataworks_aws_ingest_consumers_dataworks" {
 resource "github_branch_protection" "dataworks_aws_ingest_consumers_master" {
   branch         = github_repository.dataworks_aws_ingest_consumers.default_branch
   repository     = github_repository.dataworks_aws_ingest_consumers.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/dataworks-aws-ingest-reconcilers.tf
+++ b/dataworks-aws-ingest-reconcilers.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "dataworks_aws_ingest_reconcilers_dataworks" {
 resource "github_branch_protection" "dataworks_aws_ingest_reconcilers_master" {
   branch         = github_repository.dataworks_aws_ingest_reconcilers.default_branch
   repository     = github_repository.dataworks_aws_ingest_reconcilers.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/dataworks-aws-ingest-replica.tf
+++ b/dataworks-aws-ingest-replica.tf
@@ -31,7 +31,7 @@ resource "github_team_repository" "dataworks_aws_ingest_replica_dataworks" {
 resource "github_branch_protection" "dataworks_aws_ingest_replica_master" {
   branch         = github_repository.dataworks_aws_ingest_replica.default_branch
   repository     = github_repository.dataworks_aws_ingest_replica.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/dataworks-aws-ingestion-ecs-cluster.tf
+++ b/dataworks-aws-ingestion-ecs-cluster.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "dataworks_aws_ingestion_ecs_cluster_dataworks
 resource "github_branch_protection" "dataworks_aws_ingestion_ecs_cluster_master" {
   branch         = github_repository.dataworks_aws_ingestion_ecs_cluster.default_branch
   repository     = github_repository.dataworks_aws_ingestion_ecs_cluster.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/dataworks-aws-kickstart-adg.tf
+++ b/dataworks-aws-kickstart-adg.tf
@@ -31,7 +31,7 @@ resource "github_team_repository" "dataworks_aws_kickstart_adg_dataworks" {
 resource "github_branch_protection" "dataworks_aws_kickstart_adg_master" {
   branch         = github_repository.dataworks_aws_kickstart_adg.default_branch
   repository     = github_repository.dataworks_aws_kickstart_adg.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/dataworks-aws-s3-object-tagging.tf
+++ b/dataworks-aws-s3-object-tagging.tf
@@ -31,7 +31,7 @@ resource "github_team_repository" "dataworks_aws_s3_object_tagger_dataworks" {
 resource "github_branch_protection" "dataworks_aws_s3_object_tagger_master" {
   branch         = github_repository.dataworks_aws_s3_object_tagger.default_branch
   repository     = github_repository.dataworks_aws_s3_object_tagger.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/dataworks-aws-tarball-adg.tf
+++ b/dataworks-aws-tarball-adg.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "dataworks_aws_tarball_adg_dataworks" {
 resource "github_branch_protection" "dataworks_aws_tarball_adg_master" {
   branch         = github_repository.dataworks_aws_tarball_adg.default_branch
   repository     = github_repository.dataworks_aws_tarball_adg.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict   = true

--- a/dataworks-aws-tarball-ingester.tf
+++ b/dataworks-aws-tarball-ingester.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "dataworks_aws_tarball_ingester_dataworks" {
 resource "github_branch_protection" "dataworks_aws_tarball_ingester_master" {
   branch         = github_repository.dataworks_aws_tarball_ingester.default_branch
   repository     = github_repository.dataworks_aws_tarball_ingester.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/dataworks-aws-ucfs-claimant-consumer.tf
+++ b/dataworks-aws-ucfs-claimant-consumer.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "dataworks_aws_ucfs_claimant_consumer_datawork
 resource "github_branch_protection" "dataworks_aws_ucfs_claimant_consumer_master" {
   branch         = github_repository.dataworks_aws_ucfs_claimant_consumer.default_branch
   repository     = github_repository.dataworks_aws_ucfs_claimant_consumer.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/dataworks-aws-ucfs-stub.tf
+++ b/dataworks-aws-ucfs-stub.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "dataworks_aws_ucfs_stub_dataworks" {
 resource "github_branch_protection" "dataworks_aws_ucfs_stub_master" {
   branch         = github_repository.dataworks_aws_ucfs_stub.default_branch
   repository     = github_repository.dataworks_aws_ucfs_stub.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict   = true

--- a/dataworks-batch-job-handler.tf
+++ b/dataworks-batch-job-handler.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "dataworks_batch_job_handler_dataworks" {
 resource "github_branch_protection" "dataworks_batch_job_handler_master" {
   branch         = github_repository.dataworks_batch_job_handler.default_branch
   repository     = github_repository.dataworks_batch_job_handler.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/dataworks-behavioural-framework.tf
+++ b/dataworks-behavioural-framework.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "dataworks_behavioural_framework_dataworks" {
 resource "github_branch_protection" "dataworks_behavioural_framework_master" {
   branch         = github_repository.dataworks_behavioural_framework.default_branch
   repository     = github_repository.dataworks_behavioural_framework.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/dataworks-cognito.tf
+++ b/dataworks-cognito.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "dataworks_cognito_dataworks" {
 resource "github_branch_protection" "dataworks_cognito_master" {
   branch         = github_repository.dataworks_cognito.default_branch
   repository     = github_repository.dataworks_cognito.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict   = true

--- a/dataworks-common-logging.tf
+++ b/dataworks-common-logging.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "dataworks-common-logging-dataworks" {
 resource "github_branch_protection" "dataworks-common-logging-master" {
   branch         = github_repository.dataworks-common-logging.default_branch
   repository     = github_repository.dataworks-common-logging.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/dataworks-config.tf
+++ b/dataworks-config.tf
@@ -23,7 +23,7 @@ resource "github_team_repository" "dataworks-config_dataworks" {
 resource "github_branch_protection" "dataworks-config_master" {
   branch         = github_repository.dataworks-config.default_branch
   repository     = github_repository.dataworks-config.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/dataworks-corporate-storage-coalescence.tf
+++ b/dataworks-corporate-storage-coalescence.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "dataworks_corporate_storage_coalescence_dataw
 resource "github_branch_protection" "dataworks_corporate_storage_coalescence_master" {
   branch         = github_repository.dataworks_corporate_storage_coalescence.default_branch
   repository     = github_repository.dataworks_corporate_storage_coalescence.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/dataworks-data-egress.tf
+++ b/dataworks-data-egress.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "dataworks_data_egress_dataworks" {
 resource "github_branch_protection" "dataworks_data_egress_master" {
   branch         = github_repository.dataworks_data_egress.default_branch
   repository     = github_repository.dataworks_data_egress.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/dataworks-development-tools.tf
+++ b/dataworks-development-tools.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "dataworks_development_tools_dataworks" {
 resource "github_branch_protection" "dataworks_development_tools_master" {
   branch         = github_repository.dataworks_development_tools.default_branch
   repository     = github_repository.dataworks_development_tools.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict   = true

--- a/dataworks-emr-relauncher.tf
+++ b/dataworks-emr-relauncher.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "dataworks_emr_relauncher_dataworks" {
 resource "github_branch_protection" "dataworks_emr_relauncher_master" {
   branch         = github_repository.dataworks_emr_relauncher.default_branch
   repository     = github_repository.dataworks_emr_relauncher.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/dataworks-githooks.tf
+++ b/dataworks-githooks.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "dataworks_githooks_dataworks" {
 resource "github_branch_protection" "dataworks_githooks_master" {
   branch         = github_repository.dataworks_githooks.default_branch
   repository     = github_repository.dataworks_githooks.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/dataworks-github-config.tf
+++ b/dataworks-github-config.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "dataworks-github-config-dataworks" {
 resource "github_branch_protection" "dataworks-github-config-master" {
   branch         = github_repository.dataworks-github-config.default_branch
   repository     = github_repository.dataworks-github-config.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict   = true

--- a/dataworks-hardened-images.tf
+++ b/dataworks-hardened-images.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "dataworks_hardened_images" {
 resource "github_branch_protection" "dataworks_hardened_images_master" {
   branch         = github_repository.dataworks_hardened_images.default_branch
   repository     = github_repository.dataworks_hardened_images.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/dataworks-internet-ingress.tf
+++ b/dataworks-internet-ingress.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "dataworks_internet_ingress_dataworks" {
 resource "github_branch_protection" "dataworks_internet_ingress_master" {
   branch         = github_repository.dataworks_internet_ingress.default_branch
   repository     = github_repository.dataworks_internet_ingress.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict   = true

--- a/dataworks-metrics-infrastructure.tf
+++ b/dataworks-metrics-infrastructure.tf
@@ -26,7 +26,7 @@ resource "github_team_repository" "dataworks_metrics_infrastructure_dataworks" {
 resource "github_branch_protection" "dataworks_metrics_infrastructure_master" {
   branch         = github_repository.dataworks_metrics_infrastructure.default_branch
   repository     = github_repository.dataworks_metrics_infrastructure.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/dataworks-open-source-policy.tf
+++ b/dataworks-open-source-policy.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "dataworks-open-source-policy-dataworks" {
 resource "github_branch_protection" "dataworks-open-source-policy-master" {
   branch         = github_repository.dataworks-open-source-policy.default_branch
   repository     = github_repository.dataworks-open-source-policy.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/dataworks-pdm-emr-launcher.tf
+++ b/dataworks-pdm-emr-launcher.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "dataworks_pdm_emr_launcher_dataworks" {
 resource "github_branch_protection" "dataworks_pdm_emr_launcher_master" {
   branch         = github_repository.dataworks_pdm_emr_launcher.default_branch
   repository     = github_repository.dataworks_pdm_emr_launcher.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/dataworks-repo-template-docker.tf
+++ b/dataworks-repo-template-docker.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "dataworks_repo_template_docker_dataworks" {
 resource "github_branch_protection" "dataworks_repo_template_docker_master" {
   branch         = github_repository.dataworks_repo_template_docker.default_branch
   repository     = github_repository.dataworks_repo_template_docker.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/dataworks-repo-template-terraform.tf
+++ b/dataworks-repo-template-terraform.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "dataworks_repo_template_terraform_dataworks" 
 resource "github_branch_protection" "dataworks_repo_template_terraform_master" {
   branch         = github_repository.dataworks_repo_template_terraform.default_branch
   repository     = github_repository.dataworks_repo_template_terraform.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/dataworks-repo-template.tf
+++ b/dataworks-repo-template.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "dataworks-repo-template_dataworks" {
 resource "github_branch_protection" "dataworks-repo-template_master" {
   branch         = github_repository.dataworks-repo-template.default_branch
   repository     = github_repository.dataworks-repo-template.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/dataworks-s3-data-purger.tf
+++ b/dataworks-s3-data-purger.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "dataworks_s3_data_purger_dataworks" {
 resource "github_branch_protection" "dataworks_s3_data_purger_master" {
   branch         = github_repository.dataworks_s3_data_purger.default_branch
   repository     = github_repository.dataworks_s3_data_purger.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/dataworks-s3-object-tagger.tf
+++ b/dataworks-s3-object-tagger.tf
@@ -31,7 +31,7 @@ resource "github_team_repository" "dataworks_s3_object_tagger_dataworks" {
 resource "github_branch_protection" "dataworks_s3_object_tagger_master" {
   branch         = github_repository.dataworks_s3_object_tagger.default_branch
   repository     = github_repository.dataworks_s3_object_tagger.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/dataworks-snapshot-sender-status-checker.tf
+++ b/dataworks-snapshot-sender-status-checker.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "dataworks_snapshot_sender_status_checker_data
 resource "github_branch_protection" "dataworks_snapshot_sender_status_checker_master" {
   branch         = github_repository.dataworks_snapshot_sender_status_checker.default_branch
   repository     = github_repository.dataworks_snapshot_sender_status_checker.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/docker-alertmanager.tf
+++ b/docker-alertmanager.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "docker_alertmanager_dataworks" {
 resource "github_branch_protection" "docker_alertmanager_master" {
   branch         = github_repository.docker_alertmanager.default_branch
   repository     = github_repository.docker_alertmanager.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/docker-ansible-git.tf
+++ b/docker-ansible-git.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "docker-ansible-git-dataworks" {
 resource "github_branch_protection" "docker-ansible-git-master" {
   branch         = github_repository.docker-ansible-git.default_branch
   repository     = github_repository.docker-ansible-git.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/docker-ansible-pass-gpg.tf
+++ b/docker-ansible-pass-gpg.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "docker-ansible-pass-gpg-dataworks" {
 resource "github_branch_protection" "docker-ansible-pass-gpg-master" {
   branch         = github_repository.docker-ansible-pass-gpg.default_branch
   repository     = github_repository.docker-ansible-pass-gpg.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/docker-aviator.tf
+++ b/docker-aviator.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "docker_aviator_dataworks" {
 resource "github_branch_protection" "docker_aviator_master" {
   branch         = github_repository.docker_aviator.default_branch
   repository     = github_repository.docker_aviator.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/docker-aws-openssl.tf
+++ b/docker-aws-openssl.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "docker-aws-openssl-dataworks" {
 resource "github_branch_protection" "docker-aws-openssl-master" {
   branch         = github_repository.docker-aws-openssl.default_branch
   repository     = github_repository.docker-aws-openssl.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/docker-awscli.tf
+++ b/docker-awscli.tf
@@ -26,7 +26,7 @@ resource "github_team_repository" "docker_awscli_dataworks" {
 resource "github_branch_protection" "docker_awscli_master" {
   branch         = github_repository.docker_awscli.default_branch
   repository     = github_repository.docker_awscli.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/docker-blackbox-exporter.tf
+++ b/docker-blackbox-exporter.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "blackbox_exporter_dataworks" {
 resource "github_branch_protection" "blackbox_exporter_master" {
   branch         = github_repository.blackbox_exporter.default_branch
   repository     = github_repository.blackbox_exporter.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/docker-cloudwatch-agent.tf
+++ b/docker-cloudwatch-agent.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "cloudwatch_agent_dataworks" {
 resource "github_branch_protection" "cloudwatch_agent_master" {
   branch         = github_repository.cloudwatch_agent.default_branch
   repository     = github_repository.cloudwatch_agent.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/docker-cloudwatch-exporter.tf
+++ b/docker-cloudwatch-exporter.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "cloudwatch_exporter_dataworks" {
 resource "github_branch_protection" "cloudwatch_exporter_master" {
   branch         = github_repository.cloudwatch_exporter.default_branch
   repository     = github_repository.cloudwatch_exporter.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/docker-create-metrics-data-batch.tf
+++ b/docker-create-metrics-data-batch.tf
@@ -26,7 +26,7 @@ resource "github_team_repository" "docker_create_metrics_data_batch_dataworks" {
 resource "github_branch_protection" "docker_create_metrics_data_batch_master" {
   branch         = github_repository.docker_create_metrics_data_batch.default_branch
   repository     = github_repository.docker_create_metrics_data_batch.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/docker-ecs-service_discovery.tf
+++ b/docker-ecs-service_discovery.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "docker_ecs_service_discovery_dataworks" {
 resource "github_branch_protection" "docker_ecs_service_discovery_master" {
   branch         = github_repository.docker_ecs_service_discovery.default_branch
   repository     = github_repository.docker_ecs_service_discovery.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/docker-grafana.tf
+++ b/docker-grafana.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "docker_grafana_dataworks" {
 resource "github_branch_protection" "docker_grafana_master" {
   branch         = github_repository.docker_grafana.default_branch
   repository     = github_repository.docker_grafana.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/docker-headless-chrome.tf
+++ b/docker-headless-chrome.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "docker-headless-chrome-dataworks" {
 resource "github_branch_protection" "docker-headless-chrome-master" {
   branch         = github_repository.docker-headless-chrome.default_branch
   repository     = github_repository.docker-headless-chrome.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/docker-hive-exporter.tf
+++ b/docker-hive-exporter.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "hive_exporter_dataworks" {
 resource "github_branch_protection" "hive_exporter_master" {
   branch         = github_repository.hive_exporter.default_branch
   repository     = github_repository.hive_exporter.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/docker-hiverunner.tf
+++ b/docker-hiverunner.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "docker_hiverunner_dataworks" {
 resource "github_branch_protection" "docker_hiverunner_master" {
   branch         = github_repository.docker_hiverunner.default_branch
   repository     = github_repository.docker_hiverunner.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/docker-jinja-yaml-aws.tf
+++ b/docker-jinja-yaml-aws.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "docker-jinja-yaml-aws-dataworks" {
 resource "github_branch_protection" "docker-jinja-yaml-aws-master" {
   branch         = github_repository.docker-jinja-yaml-aws.default_branch
   repository     = github_repository.docker-jinja-yaml-aws.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/docker-jmx-exporter.tf
+++ b/docker-jmx-exporter.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "jmx_exporter_dataworks" {
 resource "github_branch_protection" "jmx_exporter_master" {
   branch         = github_repository.jmx_exporter.default_branch
   repository     = github_repository.jmx_exporter.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/docker-jq-curl.tf
+++ b/docker-jq-curl.tf
@@ -23,7 +23,7 @@ resource "github_team_repository" "docker-jq-curl-dataworks" {
 resource "github_branch_protection" "docker-jq-curl-master" {
   branch         = github_repository.docker-jq-curl.default_branch
   repository     = github_repository.docker-jq-curl.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/docker-jupyterhub.tf
+++ b/docker-jupyterhub.tf
@@ -21,7 +21,7 @@ resource "github_team_repository" "docker-jupyterhub-dataworks" {
 resource "github_branch_protection" "docker-jupyterhub-master" {
   branch         = github_repository.docker-jupyterhub.default_branch
   repository     = github_repository.docker-jupyterhub.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/docker-kafka-connect-s3.tf
+++ b/docker-kafka-connect-s3.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "docker-kafka-connect-s3-dataworks" {
 resource "github_branch_protection" "docker-kafka-connect-s3-master" {
   branch         = github_repository.docker-kafka-connect-s3.default_branch
   repository     = github_repository.docker-kafka-connect-s3.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/docker-nginx.tf
+++ b/docker-nginx.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "docker_nginx_s3_dataworks" {
 resource "github_branch_protection" "docker_nginx_s3_dataworks" {
   branch         = github_repository.docker_nginx_s3.default_branch
   repository     = github_repository.docker_nginx_s3.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/docker-nifi-s3.tf
+++ b/docker-nifi-s3.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "docker-nifi-s3-dataworks" {
 resource "github_branch_protection" "docker-nifi-s3-master" {
   branch         = github_repository.docker-nifi-s3.default_branch
   repository     = github_repository.docker-nifi-s3.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/docker-packer.tf
+++ b/docker-packer.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "packer_dataworks" {
 resource "github_branch_protection" "packer_master" {
   branch         = github_repository.packer.default_branch
   repository     = github_repository.packer.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/docker-prometheus.tf
+++ b/docker-prometheus.tf
@@ -28,7 +28,7 @@ resource "github_team_repository" "docker_prometheus_dataworks" {
 resource "github_branch_protection" "docker_prometheus_master" {
   branch         = github_repository.docker_prometheus.default_branch
   repository     = github_repository.docker_prometheus.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/docker-python-boto-behave.tf
+++ b/docker-python-boto-behave.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "docker-python-boto-behave-dataworks" {
 resource "github_branch_protection" "docker-python-boto-behave-master" {
   branch         = github_repository.docker-python-boto-behave.default_branch
   repository     = github_repository.docker-python-boto-behave.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/docker-python-pyspark-pytest.tf
+++ b/docker-python-pyspark-pytest.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "docker-python-pyspark-pytest-dataworks" {
 resource "github_branch_protection" "docker-python-pyspark-pytest-master" {
   branch         = github_repository.docker-python-pyspark-pytest.default_branch
   repository     = github_repository.docker-python-pyspark-pytest.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/docker-rstudio-oss.tf
+++ b/docker-rstudio-oss.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "rstudiooss_dataworks" {
 resource "github_branch_protection" "rstudiooss_master" {
   branch         = github_repository.rstudiooss.default_branch
   repository     = github_repository.rstudiooss.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/docker-ruby-rspec-aws-sdk.tf
+++ b/docker-ruby-rspec-aws-sdk.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "docker-ruby-rspec-aws-sdk-dataworks" {
 resource "github_branch_protection" "docker-ruby-rspec-aws-sdk-master" {
   branch         = github_repository.docker-ruby-rspec-aws-sdk.default_branch
   repository     = github_repository.docker-ruby-rspec-aws-sdk.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/docker-spark-gpg.tf
+++ b/docker-spark-gpg.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "docker-spark-gpg-dataworks" {
 resource "github_branch_protection" "docker-spark-gpg-master" {
   branch         = github_repository.docker-spark-gpg.default_branch
   repository     = github_repository.docker-spark-gpg.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/docker-squid-s3.tf
+++ b/docker-squid-s3.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "docker-squid-s3-dataworks" {
 resource "github_branch_protection" "docker-squid-s3-master" {
   branch         = github_repository.docker-squid-s3.default_branch
   repository     = github_repository.docker-squid-s3.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/docker-template-repository.tf.sample
+++ b/docker-template-repository.tf.sample
@@ -27,7 +27,7 @@ resource "github_team_repository" "example_dataworks" {
 resource "github_branch_protection" "example_master" {
   branch         = github_repository.example.default_branch
   repository     = github_repository.example.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/docker-tflint.tf
+++ b/docker-tflint.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "docker_tflint_dataworks" {
 resource "github_branch_protection" "docker_tflint_master" {
   branch         = github_repository.docker_tflint.default_branch
   repository     = github_repository.docker_tflint.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/docker-thanos.tf
+++ b/docker-thanos.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "docker_thanos_dataworks" {
 resource "github_branch_protection" "docker_thanos_master" {
   branch         = github_repository.docker_thanos.default_branch
   repository     = github_repository.docker_thanos.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/emr-cluster-broker-client.tf
+++ b/emr-cluster-broker-client.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "emr-cluster-broker-client_dataworks" {
 resource "github_branch_protection" "emr-cluster-broker-client_master" {
   branch         = github_repository.emr-cluster-broker-client.default_branch
   repository     = github_repository.emr-cluster-broker-client.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/emr-cluster-broker.tf
+++ b/emr-cluster-broker.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "emr-cluster-broker-dataworks" {
 resource "github_branch_protection" "emr-cluster-broker-master" {
   branch         = github_repository.emr-cluster-broker.default_branch
   repository     = github_repository.emr-cluster-broker.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/emr-encryption-materials-provider.tf
+++ b/emr-encryption-materials-provider.tf
@@ -26,7 +26,7 @@ resource "github_team_repository" "emr-encryption-materials-provider-dataworks" 
 resource "github_branch_protection" "emr-encryption-materials-provider-master" {
   branch         = github_repository.emr-encryption-materials-provider.default_branch
   repository     = github_repository.emr-encryption-materials-provider.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/emr-launcher.tf
+++ b/emr-launcher.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "emr-launcher_dataworks" {
 resource "github_branch_protection" "emr-launcher_master" {
   branch         = github_repository.emr-launcher.default_branch
   repository     = github_repository.emr-launcher.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/emr-template-repository.tf.sample
+++ b/emr-template-repository.tf.sample
@@ -31,7 +31,7 @@ resource "github_team_repository" "example_dataworks" {
 resource "github_branch_protection" "example_master" {
   branch         = github_repository.example.default_branch
   repository     = github_repository.example.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/external-ci-users.tf
+++ b/external-ci-users.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "external_ci_users_dataworks" {
 resource "github_branch_protection" "external_ci_users_master" {
   branch         = github_repository.external_ci_users.default_branch
   repository     = github_repository.external_ci_users.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict   = true

--- a/github-repo-config-examples.tf
+++ b/github-repo-config-examples.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "github-repo-config-examples-dataworks" {
 resource "github_branch_protection" "github-repo-config-examples-master" {
   branch         = github_repository.github-repo-config-examples.default_branch
   repository     = github_repository.github-repo-config-examples.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/hardened-guac-chrome.tf
+++ b/hardened-guac-chrome.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "hardened-guac-chrome-dataworks" {
 resource "github_branch_protection" "hardened-guac-chrome-master" {
   branch         = github_repository.hardened-guac-chrome.default_branch
   repository     = github_repository.hardened-guac-chrome.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/hbase-retriever.tf
+++ b/hbase-retriever.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "hbase-retriever-dataworks" {
 resource "github_branch_protection" "hbase-retriever-master" {
   branch         = github_repository.hbase-retriever.default_branch
   repository     = github_repository.hbase-retriever.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/hbase-table-provisioner.tf
+++ b/hbase-table-provisioner.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "hbase_table_provisioner_dataworks" {
 resource "github_branch_protection" "hbase_table_provisioner_master" {
   branch         = github_repository.hbase_table_provisioner.default_branch
   repository     = github_repository.hbase_table_provisioner.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/hbase-to-mongo-export.tf
+++ b/hbase-to-mongo-export.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "hbase-to-mongo-export-dataworks" {
 resource "github_branch_protection" "hbase-to-mongo-export-master" {
   branch         = github_repository.hbase-to-mongo-export.default_branch
   repository     = github_repository.hbase-to-mongo-export.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/historic-data-loader.tf
+++ b/historic-data-loader.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "historic_data_loader_dataworks" {
 resource "github_branch_protection" "historic_data_loader_master" {
   branch         = github_repository.historic_data_loader.default_branch
   repository     = github_repository.historic_data_loader.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/kafka-producer.tf
+++ b/kafka-producer.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "kafka-producer-dataworks" {
 resource "github_branch_protection" "kafka-producer-master" {
   branch         = github_repository.kafka-producer.default_branch
   repository     = github_repository.kafka-producer.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/kafka-queue-trawler.tf
+++ b/kafka-queue-trawler.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "kafka_queue_trawler_dataworks" {
 resource "github_branch_protection" "kafka_queue_trawler_master" {
   branch         = github_repository.kafka_queue_trawler.default_branch
   repository     = github_repository.kafka_queue_trawler.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/kafka-to-hbase-reconciliation.tf
+++ b/kafka-to-hbase-reconciliation.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "kafka_to_hbase_reconciliation_dataworks" {
 resource "github_branch_protection" "kafka_to_hbase_reconciliation_master" {
   branch         = github_repository.kafka_to_hbase_reconciliation.default_branch
   repository     = github_repository.kafka_to_hbase_reconciliation.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/kafka-to-hbase.tf
+++ b/kafka-to-hbase.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "kafka-to-hbase-dataworks" {
 resource "github_branch_protection" "kafka-to-hbase-master" {
   branch         = github_repository.kafka-to-hbase.default_branch
   repository     = github_repository.kafka-to-hbase.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/kafka-to-s3.tf
+++ b/kafka-to-s3.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "kafka-to-s3-dataworks" {
 resource "github_branch_protection" "kafka-to-s3-master" {
   branch         = github_repository.kafka-to-s3.default_branch
   repository     = github_repository.kafka-to-s3.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict   = true

--- a/manage-mysql-user.tf
+++ b/manage-mysql-user.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "manage-mysql-user-dataworks" {
 resource "github_branch_protection" "manage-mysql-user-master" {
   branch         = github_repository.manage-mysql-user.default_branch
   repository     = github_repository.manage-mysql-user.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/mock-nifi.tf
+++ b/mock-nifi.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "mock-nifi-dataworks" {
 resource "github_branch_protection" "mock-nifi-master" {
   branch         = github_repository.mock-nifi.default_branch
   repository     = github_repository.mock-nifi.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/mysql-query-lambda.tf
+++ b/mysql-query-lambda.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "dataworks_ingestion_metadata_interface_datawo
 resource "github_branch_protection" "dataworks_ingestion_metadata_interface_master" {
   branch         = github_repository.dataworks_ingestion_metadata_interface.default_branch
   repository     = github_repository.dataworks_ingestion_metadata_interface.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/orchestration-service.tf
+++ b/orchestration-service.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "orchestration-service-dataworks" {
 resource "github_branch_protection" "orchestration-service-master" {
   branch         = github_repository.orchestration-service.default_branch
   repository     = github_repository.orchestration-service.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/packer-egress-test.tf
+++ b/packer-egress-test.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "packer-egress-test-dataworks" {
 resource "github_branch_protection" "packer-egress-test-master" {
   branch         = github_repository.packer-egress-test.default_branch
   repository     = github_repository.packer-egress-test.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/registry-image-resource.tf
+++ b/registry-image-resource.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "registry-image-resource-dataworks" {
 resource "github_branch_protection" "registry-image-resource-master" {
   branch         = github_repository.registry-image-resource.default_branch
   repository     = github_repository.registry-image-resource.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/snapshot-sender.tf
+++ b/snapshot-sender.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "snapshot-sender-dataworks" {
 resource "github_branch_protection" "mongo-export-delivery-master" {
   branch         = github_repository.snapshot-sender.default_branch
   repository     = github_repository.snapshot-sender.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/ssm-parameter-store.tf
+++ b/ssm-parameter-store.tf
@@ -23,7 +23,7 @@ resource "github_team_repository" "ssm-parameter-store-dataworks" {
 resource "github_branch_protection" "ssm-parameter-store-master" {
   branch         = github_repository.ssm-parameter-store.default_branch
   repository     = github_repository.ssm-parameter-store.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/streaming-data-importer.tf
+++ b/streaming-data-importer.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "streaming_data_importer_dataworks" {
 resource "github_branch_protection" "streaming_data_importer_master" {
   branch         = github_repository.streaming_data_importer.default_branch
   repository     = github_repository.streaming_data_importer.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/tactical-aws-user-creation.tf
+++ b/tactical-aws-user-creation.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "tactical-aws-user-creation_dataworks" {
 resource "github_branch_protection" "tactical-aws-user-creation_master" {
   branch         = github_repository.tactical-aws-user-creation.default_branch
   repository     = github_repository.tactical-aws-user-creation.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/template-repository.tf.sample
+++ b/template-repository.tf.sample
@@ -27,7 +27,7 @@ resource "github_team_repository" "example_dataworks" {
 resource "github_branch_protection" "example_master" {
   branch         = github_repository.example.default_branch
   repository     = github_repository.example.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/terraform-aws-emr-cluster.tf
+++ b/terraform-aws-emr-cluster.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "terraform-aws-emr-cluster-dataworks" {
 resource "github_branch_protection" "terraform-aws-emr-cluster-master" {
   branch         = github_repository.terraform-aws-emr-cluster.default_branch
   repository     = github_repository.terraform-aws-emr-cluster.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/terraform-aws-metric-filter-alarm.tf
+++ b/terraform-aws-metric-filter-alarm.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "terraform-aws-metric-filter-alarm-dataworks" 
 resource "github_branch_protection" "terraform-aws-metric-filter-alarm-master" {
   branch         = github_repository.terraform-aws-metric-filter-alarm.default_branch
   repository     = github_repository.terraform-aws-metric-filter-alarm.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/terraform-aws-prowler-monitoring.tf
+++ b/terraform-aws-prowler-monitoring.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "terraform-aws-prowler-monitoring-dataworks" {
 resource "github_branch_protection" "terraform-aws-prowler-monitoring-master" {
   branch         = github_repository.terraform-aws-prowler-monitoring.default_branch
   repository     = github_repository.terraform-aws-prowler-monitoring.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/terraform-aws-ses-notification-service.tf
+++ b/terraform-aws-ses-notification-service.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "terraform-aws-ses-notification-service-datawo
 resource "github_branch_protection" "terraform-aws-ses-notification-service-master" {
   branch         = github_repository.terraform-aws-ses-notification-service.default_branch
   repository     = github_repository.terraform-aws-ses-notification-service.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/terraform-aws-vpc.tf
+++ b/terraform-aws-vpc.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "terraform-aws-vpc-dataworks" {
 resource "github_branch_protection" "terraform-aws-vpc-master" {
   branch         = github_repository.terraform-aws-vpc.default_branch
   repository     = github_repository.terraform-aws-vpc.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/terraform-aws-waf.tf
+++ b/terraform-aws-waf.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "terraform_aws_waf" {
 resource "github_branch_protection" "terraform_aws_waf_master" {
   branch         = github_repository.terraform_aws_waf.default_branch
   repository     = github_repository.terraform_aws_waf.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/terraform-template-repository.tf.sample
+++ b/terraform-template-repository.tf.sample
@@ -31,7 +31,7 @@ resource "github_team_repository" "example_dataworks" {
 resource "github_branch_protection" "example_master" {
   branch         = github_repository.example.default_branch
   repository     = github_repository.example.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/uc-historic-data-importer.tf
+++ b/uc-historic-data-importer.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "uc-historic-data-importer-dataworks" {
 resource "github_branch_protection" "uc-historic-data-importer-master" {
   branch         = github_repository.uc-historic-data-importer.default_branch
   repository     = github_repository.uc-historic-data-importer.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/ucfs-claimant-api-load-data.tf
+++ b/ucfs-claimant-api-load-data.tf
@@ -22,7 +22,7 @@ resource "github_team_repository" "ucfs-claimant-api-load-data_dataworks" {
 resource "github_branch_protection" "ucfs-claimant-api-load-data_master" {
   branch         = github_repository.ucfs-claimant-api-load-data.default_branch
   repository     = github_repository.ucfs-claimant-api-load-data.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/ucfs-claimant-api-mysql-interface.tf
+++ b/ucfs-claimant-api-mysql-interface.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "ucfs_claimant_api_mysql_interface_dataworks" 
 resource "github_branch_protection" "ucfs_claimant_api_mysql_interface_master" {
   branch         = github_repository.ucfs_claimant_api_mysql_interface.default_branch
   repository     = github_repository.ucfs_claimant_api_mysql_interface.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/ucfs-claimant-api-replayer-additional-data.tf
+++ b/ucfs-claimant-api-replayer-additional-data.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "ucfs_claimant_api_replayer_mismatch_handler_d
 resource "github_branch_protection" "ucfs_claimant_api_replayer_mismatch_handler_master" {
   branch         = github_repository.ucfs_claimant_api_replayer_mismatch_handler.default_branch
   repository     = github_repository.ucfs_claimant_api_replayer_mismatch_handler.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/ucfs-claimant-api-replayer.tf
+++ b/ucfs-claimant-api-replayer.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "ucfs_claimant_api_replayer_dataworks" {
 resource "github_branch_protection" "ucfs_claimant_api_replayer_master" {
   branch         = github_repository.ucfs_claimant_api_replayer.default_branch
   repository     = github_repository.ucfs_claimant_api_replayer.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/ucfs-claimant-get-award-details.tf
+++ b/ucfs-claimant-get-award-details.tf
@@ -23,7 +23,7 @@ resource "github_team_repository" "ucfs-claimant-get-award-details_dataworks" {
 resource "github_branch_protection" "ucfs-claimant-get-award-details_master" {
   branch         = github_repository.ucfs-claimant-get-award-details.default_branch
   repository     = github_repository.ucfs-claimant-get-award-details.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true

--- a/ucfs-claimant-kafka-consumer.tf
+++ b/ucfs-claimant-kafka-consumer.tf
@@ -27,7 +27,7 @@ resource "github_team_repository" "ucfs_claimant_kafka_consumer_dataworks" {
 resource "github_branch_protection" "ucfs_claimant_kafka_consumer_master" {
   branch         = github_repository.ucfs_claimant_kafka_consumer.default_branch
   repository     = github_repository.ucfs_claimant_kafka_consumer.name
-  enforce_admins = false
+  enforce_admins = true
 
   required_status_checks {
     strict = true


### PR DESCRIPTION
Currently admins can avoid branch protection rules, and push directly to `master`.  This should be a conscious choice, and should not happen by accident.